### PR TITLE
feat(zsh): add jl alias for just --list

### DIFF
--- a/nix/users/kelvin/hm/zsh.nix
+++ b/nix/users/kelvin/hm/zsh.nix
@@ -36,6 +36,7 @@ in
       tigh = "tig -a HEAD";
       # Dev aliases
       j = "just";
+      jl = "just --list";
       # Editor aliases
       c = "code .";
       h = "hx .";


### PR DESCRIPTION
Adds `jl` as a shorthand alias for `just --list`, complementing the existing `j` alias for `just`.