### PR TITLE
git: submodule-aware defaults + recursive-clone alias

### DIFF
--- a/modules/features/git.nix
+++ b/modules/features/git.nix
@@ -11,9 +11,27 @@ _: {
         pull.rebase = "merges";
         init.defaultBranch = "master";
         color.ui = true;
+        # Submodule ergonomics. The parent repo is the source of truth for
+        # which submodule commits are checked out; these make that state
+        # visible at the moments mistakes usually happen. See
+        # steinerkelvin/dotfiles#12 for the matching `git-sub` tooling.
+        # Recurse into submodules for checkout/pull/switch/reset (NOT clone --
+        # git excludes clone; use `git cloner` or the consumer repo's devshell
+        # shellHook for first-time init).
+        submodule.recurse = true;
+        # status/diff surface submodule state instead of an opaque gitlink line.
+        status.submoduleSummary = true;
+        diff.submodule = "log";
+        # Refuse to push a parent commit that references submodule commits not
+        # reachable from a configured remote (the core footgun gate).
+        push.recurseSubmodules = "check";
+        # Fetch submodule commits on demand when parent pointers move.
+        fetch.recurseSubmodules = "on-demand";
         alias = {
           # Explicit difftastic diff shortcut
           difft = "!git -c diff.external=difft diff";
+          # Recursive clone (global config can't auto-recurse `clone`).
+          cloner = "clone --recurse-submodules";
         };
       };
     };


### PR DESCRIPTION
Make git submodules predictable by surfacing their state at the moments mistakes usually happen, via global defaults in the `git` home module (included by `base-dev`).

- `submodule.recurse=true` -- recurse on checkout/pull/switch/reset (not clone; git excludes it).
- `status.submoduleSummary=true`, `diff.submodule=log` -- show submodule changes and pointer commit-ranges instead of opaque gitlink lines.
- `push.recurseSubmodules=check` -- refuse to push a parent commit referencing submodule commits not reachable from a configured remote (the core footgun gate).
- `fetch.recurseSubmodules=on-demand` -- pull submodule commits when parent pointers move.
- `git cloner` alias -- recursive clone, since clone can't be configured to recurse globally.

First-time init and the clone gap are handled per-repo (a devshell `shellHook` / `just setup` that runs `git submodule update --init --recursive`).

Tooling follow-up (a `git-sub` CLI with `check`/`status` + hook/CI wiring): #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cloner` alias for recursive submodule cloning.

* **Chores**
  * Enhanced Git configuration for improved submodule handling, including automatic recursive operations during checkout, pull, switch, and reset; better submodule status visibility; and on-demand submodule fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/steinerkelvin/dotfiles/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->